### PR TITLE
Make it not crash on android

### DIFF
--- a/osu.Game.Rulesets.RurusettoAddon/API/RurusettoAPI.cs
+++ b/osu.Game.Rulesets.RurusettoAddon/API/RurusettoAPI.cs
@@ -69,8 +69,8 @@ public partial class RurusettoAPI : Component {
 	}
 
 	// mobile doesnt have HttpClient.GetStringAsync
-	private static async Task<T> JsonWebRequest<T>(string apiPath) {
-		var req = new OsuJsonWebRequest<T>(DefaultAPIAddress + apiPath);
+	private async Task<T> JsonWebRequest<T>(string apiPath) {
+		var req = new OsuJsonWebRequest<T>(GetEndpoint(apiPath).AbsoluteUri);
 		await req.PerformAsync();
 		return req.ResponseObject;
 	}

--- a/osu.Game.Rulesets.RurusettoAddon/API/RurusettoAPI.cs
+++ b/osu.Game.Rulesets.RurusettoAddon/API/RurusettoAPI.cs
@@ -1,16 +1,16 @@
-﻿using Newtonsoft.Json;
-using osu.Framework.Graphics.Rendering;
+﻿using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
+using osu.Game.Online.API;
 using SixLabors.ImageSharp.PixelFormats;
 using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace osu.Game.Rulesets.RurusettoAddon.API;
 
-public class RurusettoAPI : Component {
+public partial class RurusettoAPI : Component {
 	private HttpClient client = new();
-	public const string DefaultAPIAddress = "https://rulesets.info/api/";
+	public const string DefaultAPIAddress = "https://rulesets.info/api";
 	public readonly Bindable<string> Address = new( DefaultAPIAddress );
 	public Uri GetEndpoint ( string endpoint ) => new( new Uri( Address.Value ), endpoint );
 
@@ -67,9 +67,16 @@ public class RurusettoAPI : Component {
 
 		queue( listingCache ??= requestRulesetListing(), success, failure, cancelled );
 	}
+
+	// mobile doesnt have HttpClient.GetStringAsync
+	private static async Task<T> JsonWebRequest<T>(string apiPath) {
+		var req = new OsuJsonWebRequest<T>(DefaultAPIAddress + apiPath);
+		await req.PerformAsync();
+		return req.ResponseObject;
+	}
+
 	private async Task<IEnumerable<ListingEntry>?> requestRulesetListing () {
-		var raw = await client.GetStringAsync( GetEndpoint( "/api/rulesets" ) );
-		return JsonConvert.DeserializeObject<List<ListingEntry>>( raw );
+		return await JsonWebRequest<List<ListingEntry>>("/rulesets");
 	}
 	public void FlushRulesetListingCache () {
 		listingCache = null;
@@ -86,8 +93,7 @@ public class RurusettoAPI : Component {
 		queue( detail, success, failure );
 	}
 	private async Task<RulesetDetail?> requestRulesetDetail ( string slug ) {
-		var raw = await client.GetStringAsync( GetEndpoint( $"/api/rulesets/{slug}" ) );
-		return JsonConvert.DeserializeObject<RulesetDetail>( raw );
+		return await JsonWebRequest<RulesetDetail?>($"/rulesets/{slug}");
 	}
 	public void FlushRulesetDetailCache ( string shortName ) {
 		rulesetDetailCache.Remove( shortName );
@@ -107,8 +113,7 @@ public class RurusettoAPI : Component {
 		queue( listing, success, failure );
 	}
 	private async Task<IEnumerable<SubpageListingEntry>?> requestSubpageListing ( string slug ) {
-		var raw = await client.GetStringAsync( GetEndpoint( $"/api/subpage/{slug}" ) );
-		return JsonConvert.DeserializeObject<List<SubpageListingEntry>>( raw );
+		return await JsonWebRequest<List<SubpageListingEntry>>($"/subpage/{slug}");
 	}
 	public void FlushSubpageListingCache ( string shortName ) {
 		subpageListingCache.Remove( shortName );
@@ -128,8 +133,7 @@ public class RurusettoAPI : Component {
 		queue( listing, success, failure );
 	}
 	private async Task<Subpage?> requestSubpage ( string rulesetSlug, string subpageSlug ) {
-		var raw = await client.GetStringAsync( GetEndpoint( $"/api/subpage/{rulesetSlug}/{subpageSlug}" ) );
-		return JsonConvert.DeserializeObject<Subpage>( raw );
+		return await JsonWebRequest<Subpage>($"/subpage/{rulesetSlug}/{subpageSlug}");
 	}
 	public void FlushSubpageCache ( string rulesetSlug, string subpageSlug ) {
 		subpageCache.Remove( $"{rulesetSlug}/{subpageSlug}" );
@@ -159,14 +163,12 @@ public class RurusettoAPI : Component {
 		queue( list, success, failure );
 	}
 	private async Task<List<BeatmapRecommendation>?> requestBeatmapRecommendations ( string rulesetSlug, RecommendationSource source ) {
-		var url = $"/api/rulesets/{rulesetSlug}/beatmaps";
+		var apiPath = $"/rulesets/{rulesetSlug}/beatmaps";
 		if ( source is RecommendationSource.Author )
-			url += "/creator";
+			apiPath += "/creator";
 		else if ( source is RecommendationSource.Users )
-			url += "/players";
-
-		var raw = await client.GetStringAsync( GetEndpoint( url ) );
-		return JsonConvert.DeserializeObject<List<BeatmapRecommendation>>( raw );
+			apiPath += "/players";
+		return await JsonWebRequest<List<BeatmapRecommendation>>(apiPath);
 	}
 	public void FlushBeatmapRecommendationsCache ( string rulesetSlug, RecommendationSource source ) {
 		recommmendationCache.Remove( (rulesetSlug, source) );
@@ -191,8 +193,7 @@ public class RurusettoAPI : Component {
 		queue( user, success, failure );
 	}
 	private async Task<UserProfile?> requestUserProfile ( int id ) {
-		var raw = await client.GetStringAsync( GetEndpoint( $"/api/profile/{id}" ) );
-		return JsonConvert.DeserializeObject<UserProfile>( raw );
+		return await JsonWebRequest<UserProfile>($"/profile/{id}");
 	}
 	public void FlushUserProfileCache ( int id ) {
 		userCache.Remove( id );
@@ -216,7 +217,8 @@ public class RurusettoAPI : Component {
 			throw new InvalidOperationException( $"Images can only be requested from `/media/` and `/static/` endpoints, but `{uri}` was requested." );
 
 		var imageStream = await client.GetStreamAsync( GetEndpoint( uri ) );
-		var image = await Image.LoadAsync<Rgba32>( imageStream );
+		// mobile dotnet doesn't have Image.LoadAsync
+		var image = await Task.Run(() => Image.Load<Rgba32>(imageStream));
 
 		var texture = renderer.CreateTexture( image.Width, image.Height );
 		texture.SetData( new TextureUpload( image ) );

--- a/osu.Game.Rulesets.RurusettoAddon/RulesetDownloader.cs
+++ b/osu.Game.Rulesets.RurusettoAddon/RulesetDownloader.cs
@@ -57,10 +57,10 @@ namespace osu.Game.Rulesets.RurusettoAddon {
 					if ( File.Exists( ruleset.LocalPath ) ) {
 						var info = new FileInfo( ruleset.LocalPath );
 						info.Refresh();
-
+						using var stream = File.OpenRead(ruleset.LocalPath);
 						if ( s.LatestUpdate.HasValue && info.LastWriteTimeUtc < s.LatestUpdate.Value )
 							availability.Value |= Availability.Outdated;
-						else if ( s.FileSize != 0 && info.Length != s.FileSize )
+						else if ( s.FileSize != 0 && stream.Length != s.FileSize )
 							availability.Value |= Availability.Outdated;
 					}
 				}
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.RurusettoAddon {
 
 				var filename = $"./rurusetto-addon-temp/{detail.GithubFilename}";
 				if ( !storage.Exists( filename ) ) {
-					using var data = await new HttpClient().GetStreamAsync( detail.Download );
+					using var data = await new HttpClient().GetStreamAsync( new Uri(detail.Download) );
 					if ( wasTaskCancelled( ruleset, task ) ) return;
 
 					using var file = storage.GetStream( filename, FileAccess.Write, FileMode.OpenOrCreate );


### PR DESCRIPTION
The usual deal of the lazer APK trimming out unused classes/methods from the bundled .NET runtime
Still have this one left but it isn't causing a crash upon pressing the report/webpage buttons on ruleset details.
```
System.MissingMethodException: Method not found: void osu.Game.OsuGame.OpenUrlExternally(string,bool)
```